### PR TITLE
upgrade orangep-pi-lite to latest kernel and uboot

### DIFF
--- a/layers/meta-resin-allwinner/conf/machine/orange-pi-lite.conf
+++ b/layers/meta-resin-allwinner/conf/machine/orange-pi-lite.conf
@@ -4,8 +4,8 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_linux = "4.11%"
-PREFERRED_VERSION_u-boot = "v2017.03%"
+PREFERRED_VERSION_linux = "4.14%"
+PREFERRED_VERSION_u-boot = "v2017.11%"
 
 KERNEL_DEVICETREE = "sun8i-h3-orangepi-lite.dtb \ 
 overlay/sun8i-h3-analog-codec.dtbo \

--- a/orange-pi-lite.coffee
+++ b/orange-pi-lite.coffee
@@ -22,7 +22,7 @@ module.exports =
 		machine: 'orange-pi-lite'
 		image: 'resin-image'
 		fstype: 'resinos-img'
-		version: 'yocto-morty'
+		version: 'yocto-pyro'
 		deployArtifact: 'resin-image-orange-pi-lite.resinos-img'
 		compressed: true
 


### PR DESCRIPTION
closes #17 